### PR TITLE
Simple version fix to egui_extras to match egui fixing win11 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ game-data = { path = "game_data" }
 egui = "0.27.2"
 
 eframe = { version = "0.27.2", features = ["persistence"] }
-egui_extras = { version = "*", features = ["all_loaders"] }
+egui_extras = { version = "0.27.2", features = ["all_loaders"] }
 image = { version = "0.24", features = ["jpeg", "png"] }
 wasm-bindgen-futures = "0.4"
 gloo-worker = { version = "0.5.0", features = ["futures"] }


### PR DESCRIPTION
Real simple change to specify a version for egui_extras and fix building on windows 11. 